### PR TITLE
Changed retrieve functions to have as input a whole ciphertext

### DIFF
--- a/include/core/ggsw/ggsw_ciphertext.h
+++ b/include/core/ggsw/ggsw_ciphertext.h
@@ -66,14 +66,13 @@ void delete_ggsw(GGSWCiphertext* ggsw);
  *
  * The function takes j and i and get the associated bivGLWE.
  *
- * @param params_ggsw A Pointer to the GGSW parameters. Contains `kappa_tilde`.
- * @param ggsw_mat    A Pointer to The GGSW ciphertext's matrix.
+ * @param ggsw_ct    A Pointer to The GGSW ciphertext
  * @param j 		  The j-th component of the secret key.
  * @param i 		  The i in -m * sk_j / 2^{kappa_tilde * i}.
  *
  * @return A Pointer to the associated Bivariate GLWE.
  */
-VecBiv* ggsw_retrieve_bivglwe(const GGSWParams* params_ggsw, MatBiv* ggsw_mat, int64_t j, int64_t i);
+VecBiv* ggsw_retrieve_bivglwe(GGSWCiphertext* ggsw_ct, int64_t j, int64_t i);
 
 /**
  * @brief Normalizes a GGSW ciphertext.
@@ -175,14 +174,13 @@ void delete_ggsw_dft(GGSWCiphertextDFT* ggsw_dft);
  *
  * The function takes j and i and get the associated bivGLWE.
  *
- * @param params_ggsw A Pointer to the GGSW parameters. Contains `kappa_tilde`.
- * @param ggsw_mat    A Pointer to The GGSW ciphertext's matrix.
+ * @param ggsw_dft_ct    A Pointer to The GGSW ciphertext
  * @param j 		  The j-th component of the secret key.
  * @param i 		  The i in -m * sk_j / 2^{kappa_tilde * i}.
  *
  * @return A Pointer to the associated Bivariate GLWE in the DFT space.
  */
-VecBivDFT* ggsw_retrieve_bivglwe_dft(const GGSWParams* params_ggsw, MatBivDFT* ggsw_mat_dft, int64_t j, int64_t i);
+VecBivDFT* ggsw_retrieve_bivglwe_dft(GGSWCiphertextDFT* ggsw_dft_ct, int64_t j, int64_t i);
 
 /**
  * @brief Normalizes a GGSW ciphertext in the DFT space.

--- a/src/core/ggsw/ggsw.c
+++ b/src/core/ggsw/ggsw.c
@@ -88,7 +88,7 @@ int ggsw_secret_encrypt(const MODULE* module, GGSWCiphertext* result, const GLWE
 				CHECK_CALL(univ_to_biv(params_glwe, glwe_biv_msg, tmp_sp1), "univ_to_biv failed in compute_phase_ij");
 			}
 			// Get the pointer for the result position
-			VecBiv* glwe_vec       = ggsw_retrieve_bivglwe(params_ggsw, result->mat, j, i);
+			VecBiv* glwe_vec       = ggsw_retrieve_bivglwe(result, j, i);
 			GLWECiphertext glwe_ct = {params_glwe, glwe_vec};
 
 			//Compute: bivGLWE(glwe_biv_msg) into glwe_vec
@@ -237,7 +237,7 @@ int ggsw_secret_encrypt_dft(const MODULE* module, GGSWCiphertextDFT* result_dft,
 			                 poly_biv_size(params_glwe), N);
 
 			// Result destination
-			VecBivDFT* glwe_vec_dft = ggsw_retrieve_bivglwe_dft(params_ggsw, result_dft->mat, j, i);
+			VecBivDFT* glwe_vec_dft = ggsw_retrieve_bivglwe_dft(result_dft, j, i);
 
 			// Finally, mask/encrypt the above result to get a bivGLWE
 

--- a/src/core/ggsw/ggsw_ciphertext.c
+++ b/src/core/ggsw/ggsw_ciphertext.c
@@ -43,15 +43,15 @@ void delete_ggsw(GGSWCiphertext* ggsw)
 }
 
 // TODO: add inline qualifier
-VecBiv* ggsw_retrieve_bivglwe(const GGSWParams* params_ggsw, MatBiv* ggsw_mat, int64_t j, int64_t i)
+VecBiv* ggsw_retrieve_bivglwe(GGSWCiphertext* ggsw_ct, int64_t j, int64_t i)
 {
 	// bivGLWE parameters
-	const GLWEParams* params_glwe = params_ggsw->params_glwe;
+	const GLWEParams* params_glwe = ggsw_ct->params->params_glwe;
 
 	// bivGGSW parameters
-	uint64_t k_tilde = params_ggsw->k_tilde;
+	uint64_t k_tilde = ggsw_ct->params->k_tilde;
 
-	return ggsw_mat + ((i - 1) * (k_tilde + 1) + j) * glwe_coef_number(params_glwe);
+	return ggsw_ct->mat + ((i - 1) * (k_tilde + 1) + j) * glwe_coef_number(params_glwe);
 }
 
 int normalize_ggsw(const MODULE* module, GGSWCiphertext* result, const GGSWCiphertext* ggsw)
@@ -70,7 +70,7 @@ int normalize_ggsw(const MODULE* module, GGSWCiphertext* result, const GGSWCiphe
 		for (uint64_t j = 0; j < ggsw_num_rows_per_pggsw(params_ggsw); j++)
 		{
 			// The pointer to biGLWE(-m * sk_j * Y^i)
-			VecBiv* result_glwe_vec = ggsw_retrieve_bivglwe(params_ggsw, result->mat, j, i);
+			VecBiv* result_glwe_vec = ggsw_retrieve_bivglwe(result, j, i);
 
 			// Normalize the k+1 bivGLWE's elements
 			for (uint64_t t = 0; t < k + 1; t++)
@@ -161,15 +161,15 @@ void delete_ggsw_dft(GGSWCiphertextDFT* ggsw_dft)
 	free(ggsw_dft);
 }
 
-VecBivDFT* ggsw_retrieve_bivglwe_dft(const GGSWParams* params_ggsw, MatBivDFT* ggsw_mat_dft, int64_t j, int64_t i)
+VecBivDFT* ggsw_retrieve_bivglwe_dft(GGSWCiphertextDFT* ggsw_dft_ct, int64_t j, int64_t i)
 {
 	// bivGLWE parameters
-	const GLWEParams* params_glwe = params_ggsw->params_glwe;
+	const GLWEParams* params_glwe = ggsw_dft_ct->params->params_glwe;
 
 	// bivGGSW parameters
-	uint64_t k_tilde = params_ggsw->k_tilde;
+	uint64_t k_tilde = ggsw_dft_ct->params->k_tilde;
 
-	return ggsw_mat_dft + ((i - 1) * (k_tilde + 1) + j) * 2 * glwe_coef_number_dft(params_glwe);
+	return ggsw_dft_ct->mat + ((i - 1) * (k_tilde + 1) + j) * 2 * glwe_coef_number_dft(params_glwe);
 }
 
 int normalize_ggsw_dft(const MODULE* module, GGSWCiphertextDFT* result_dft, const GGSWCiphertextDFT* ggsw_dft)

--- a/tests/unit/core/ggsw/test_ggsw_ciphertext.c
+++ b/tests/unit/core/ggsw/test_ggsw_ciphertext.c
@@ -99,7 +99,7 @@ Test(ggsw_Sj_Yti, basic)
 	for (uint64_t i = 1; i < ggsw_num_pggsw(params_ggsw); i++)
 		for (uint64_t j = 0; j < K_TILDEBASE + 1; j++)
 		{
-			VecBiv* ct_mat_ij = ggsw_retrieve_bivglwe(params_ggsw, ggsw->mat, j, i);
+			VecBiv* ct_mat_ij = ggsw_retrieve_bivglwe(ggsw, j, i);
 
 			// Modify the two firsts coefficients of biGLWE(-m * sk_j / 2^{kappa_tilde * i}).
 			ct_mat_ij[0] = 1;
@@ -214,8 +214,8 @@ Test(const_mult_ggsw, without_normalization)
 	for (uint64_t ii = 1; ii <= ggsw_num_pggsw(params_ggsw); ii++)
 		for (uint64_t jj = 0; jj < K_TILDEBASE + 1; jj++)
 		{
-			VecBiv* ct_mat_ii_jj  = ggsw_retrieve_bivglwe(params_ggsw, ggsw->mat, jj, ii);
-			VecBiv* res_mat_ii_jj = ggsw_retrieve_bivglwe(params_ggsw, product_computed->mat, jj, ii);
+			VecBiv* ct_mat_ii_jj  = ggsw_retrieve_bivglwe(ggsw, jj, ii);
+			VecBiv* res_mat_ii_jj = ggsw_retrieve_bivglwe(product_computed, jj, ii);
 			for (uint64_t j = 0; j < KBASE + 1; j++)
 				for (uint64_t p = 0; p < NBASE; p++)
 					for (uint64_t i = 1; i <= LBASE; i++)
@@ -275,8 +275,8 @@ Test(const_mult_ggsw, with_normalization)
 	for (uint64_t ii = 1; ii <= ggsw_num_pggsw(params_ggsw); ii++)
 		for (uint64_t jj = 0; jj < K_TILDEBASE + 1; jj++)
 		{
-			VecBiv* ct_mat_ii_jj  = ggsw_retrieve_bivglwe(params_ggsw, ggsw->mat, jj, ii);
-			VecBiv* res_mat_ii_jj = ggsw_retrieve_bivglwe(params_ggsw, product_computed->mat, jj, ii);
+			VecBiv* ct_mat_ii_jj  = ggsw_retrieve_bivglwe(ggsw, jj, ii);
+			VecBiv* res_mat_ii_jj = ggsw_retrieve_bivglwe(product_computed, jj, ii);
 
 			for (uint64_t j = 0; j < KBASE + 1; j++)
 				for (uint64_t p = 0; p < NBASE; p++)
@@ -373,7 +373,7 @@ Test(ggsw_Sj_Yti_dft, basic)
 	for (uint64_t i = 1; i < ggsw_num_pggsw(params_ggsw); i++)
 		for (uint64_t j = 0; j < K_TILDEBASE + 1; j++)
 		{
-			VecBivDFT* ct_mat_ij = ggsw_retrieve_bivglwe_dft(params_ggsw, ggsw_dft->mat, j, i);
+			VecBivDFT* ct_mat_ij = ggsw_retrieve_bivglwe_dft(ggsw_dft, j, i);
 
 			// Modify the two firsts coefficients of biGLWE(-m * sk_j / 2^{kappa_tilde * i}).
 			ct_mat_ij[0] = 0.1;
@@ -475,8 +475,8 @@ Test(const_mult_ggsw_dft, without_normalization)
 	GGSWCiphertextDFT* ggsw_dft          = new_ggsw_dft(params_ggsw);
 	GGSWCiphertextDFT* prod_computed_dft = new_ggsw_dft(params_ggsw);
 	PolyUniv* u                          = malloc(NBASE * sizeof(double));
-	MatBiv* ggsw_mat                     = malloc(ggsw_bytes(params_ggsw));
-	MatBiv* prod_computed_mat            = malloc(ggsw_bytes(params_ggsw));
+	GGSWCiphertext* ggsw_ct              = new_ggsw(params_ggsw);
+	GGSWCiphertext* prod_comp            = new_ggsw(params_ggsw);
 
 	// Draws uniformly the Zn[X] polynomial in the DFT domain
 	uniform_random_vec_znx_dft(module, u_dft, 1, KAPPABASE - 1);
@@ -489,16 +489,15 @@ Test(const_mult_ggsw_dft, without_normalization)
 
 	// Computes the matrix of u_dft, ggsw_dft and prod_computed_dft out of the DFT domain
 	pvda_vec_znx_idft(module, u, 1, u_dft, 1);
-	pvda_vec_znx_idft(module, ggsw_mat, ggsw_size(params_ggsw), ggsw_dft->mat, ggsw_size(params_ggsw));
-	pvda_vec_znx_idft(module, prod_computed_mat, ggsw_size(params_ggsw), prod_computed_dft->mat,
-	                  ggsw_size(params_ggsw));
+	pvda_vec_znx_idft(module, ggsw_ct->mat, ggsw_size(params_ggsw), ggsw_dft->mat, ggsw_size(params_ggsw));
+	pvda_vec_znx_idft(module, prod_comp->mat, ggsw_size(params_ggsw), prod_computed_dft->mat, ggsw_size(params_ggsw));
 
 	// Asserts prod_computed_dft = DFT(u) * DFT(ggsw)
 	for (uint64_t ii = 1; ii <= ggsw_num_pggsw(params_ggsw); ii++)
 		for (uint64_t jj = 0; jj < K_TILDEBASE + 1; jj++)
 		{
-			VecBiv* ct_mat_ii_jj  = ggsw_retrieve_bivglwe(params_ggsw, ggsw_mat, jj, ii);
-			VecBiv* res_mat_ii_jj = ggsw_retrieve_bivglwe(params_ggsw, prod_computed_mat, jj, ii);
+			VecBiv* ct_mat_ii_jj  = ggsw_retrieve_bivglwe(ggsw_ct, jj, ii);
+			VecBiv* res_mat_ii_jj = ggsw_retrieve_bivglwe(prod_comp, jj, ii);
 			for (uint64_t j = 0; j < KBASE + 1; j++)
 				for (uint64_t p = 0; p < NBASE; p++)
 					for (uint64_t i = 1; i <= LBASE; i++)
@@ -523,8 +522,8 @@ Test(const_mult_ggsw_dft, without_normalization)
 	// Clean up
 	free(u);
 	free(u_dft);
-	free(ggsw_mat);
-	free(prod_computed_mat);
+	delete_ggsw(ggsw_ct);
+	delete_ggsw(prod_comp);
 	delete_ggsw_dft(ggsw_dft);
 	delete_ggsw_dft(prod_computed_dft);
 	delete_ggsw_params(params_ggsw);
@@ -544,8 +543,8 @@ Test(const_mult_ggsw_dft, with_normalization)
 	GGSWCiphertextDFT* ggsw_dft          = new_ggsw_dft(params_ggsw);
 	GGSWCiphertextDFT* prod_computed_dft = new_ggsw_dft(params_ggsw);
 	PolyUniv* u                          = malloc(NBASE * sizeof(double));
-	MatBiv* ggsw_mat                     = malloc(ggsw_bytes(params_ggsw));
-	MatBiv* prod_computed_mat            = malloc(ggsw_bytes(params_ggsw));
+	GGSWCiphertext* ggsw_ct              = new_ggsw(params_ggsw);
+	GGSWCiphertext* prod_comp            = new_ggsw(params_ggsw);
 
 	// Draws uniformly the Zn[X] polynomial in the DFT domain
 	uniform_random_vec_znx_dft(module, u_dft, 1, KAPPABASE - 1);
@@ -558,15 +557,14 @@ Test(const_mult_ggsw_dft, with_normalization)
 
 	// Computes the matrix of u_dft, ggsw_dft and prod_computed_dft out of the DFT domain
 	pvda_vec_znx_idft(module, u, 1, u_dft, 1);
-	pvda_vec_znx_idft(module, ggsw_mat, ggsw_size(params_ggsw), ggsw_dft->mat, ggsw_size(params_ggsw));
-	pvda_vec_znx_idft(module, prod_computed_mat, ggsw_size(params_ggsw), prod_computed_dft->mat,
-	                  ggsw_size(params_ggsw));
+	pvda_vec_znx_idft(module, ggsw_ct->mat, ggsw_size(params_ggsw), ggsw_dft->mat, ggsw_size(params_ggsw));
+	pvda_vec_znx_idft(module, prod_comp->mat, ggsw_size(params_ggsw), prod_computed_dft->mat, ggsw_size(params_ggsw));
 
 	for (uint64_t ii = 1; ii <= ggsw_num_pggsw(params_ggsw); ii++)
 		for (uint64_t jj = 0; jj < K_TILDEBASE + 1; jj++)
 		{
-			VecBiv* ct_mat_ii_jj  = ggsw_retrieve_bivglwe(params_ggsw, ggsw_mat, jj, ii);
-			VecBiv* res_mat_ii_jj = ggsw_retrieve_bivglwe(params_ggsw, prod_computed_mat, jj, ii);
+			VecBiv* ct_mat_ii_jj  = ggsw_retrieve_bivglwe(ggsw_ct, jj, ii);
+			VecBiv* res_mat_ii_jj = ggsw_retrieve_bivglwe(prod_comp, jj, ii);
 			for (uint64_t j = 0; j < KBASE + 1; j++)
 				for (uint64_t p = 0; p < NBASE; p++)
 				{
@@ -604,8 +602,8 @@ Test(const_mult_ggsw_dft, with_normalization)
 	// Clean up
 	free(u);
 	free(u_dft);
-	free(ggsw_mat);
-	free(prod_computed_mat);
+	delete_ggsw(ggsw_ct);
+	delete_ggsw(prod_comp);
 	delete_ggsw_dft(ggsw_dft);
 	delete_ggsw_dft(prod_computed_dft);
 	delete_ggsw_params(params_ggsw);

--- a/tests/unit/core/ggsw/test_ggsw_encrypt.c
+++ b/tests/unit/core/ggsw/test_ggsw_encrypt.c
@@ -88,7 +88,7 @@ Test(ggsw_secret_encrypt, works)
 			memset(phase_univ_RnX, 0, poly_univ_bytes(params_glwe));
 
 			// Computes the phase = -m * sk_j / 2^{kappa_tilde * i}) + err
-			GLWECiphertext glwe_ct = {params_glwe, ggsw_retrieve_bivglwe(params_ggsw, ggsw->mat, j, i)};
+			GLWECiphertext glwe_ct = {params_glwe, ggsw_retrieve_bivglwe(ggsw, j, i)};
 			glwe_secret_demasking(module, phase_computed, sk_dft, &glwe_ct);
 			biv_to_univ(params_glwe, phase_computed_univ_RnX, phase_computed);
 
@@ -258,7 +258,7 @@ Test(ggsw_secret_encrypt_dft, works)
 			memset(phase_univ_RnX, 0, poly_univ_bytes(params_glwe));
 
 			// Computes the phase = -m * sk_j / 2^{kappa_tilde * i}) + err
-			GLWECiphertextDFT glwe_dft_ct = {params_glwe, ggsw_retrieve_bivglwe_dft(params_ggsw, ggsw_dft->mat, j, i)};
+			GLWECiphertextDFT glwe_dft_ct = {params_glwe, ggsw_retrieve_bivglwe_dft(ggsw_dft, j, i)};
 			glwe_secret_demasking_dft(module, phase_computed, sk_dft, &glwe_dft_ct);
 
 			// Computes the phase = -m * sk_j / 2^{kappa_tilde * i} + err in RnX


### PR DESCRIPTION
First very small refactor. 

Changed a function that needed to get the underlying ciphertext data and parameters separately to now only require a ciphertext object. 