### PR TITLE
Key flattening

### DIFF
--- a/include/core/ggsw/ggsw_ciphertext.h
+++ b/include/core/ggsw/ggsw_ciphertext.h
@@ -66,14 +66,13 @@ void delete_ggsw(GGSWCiphertext* ggsw);
  *
  * The function takes j and i and get the associated bivGLWE.
  *
- * @param params_ggsw A Pointer to the GGSW parameters. Contains `kappa_tilde`.
- * @param ggsw_mat    A Pointer to The GGSW ciphertext's matrix.
+ * @param ggsw_ct    A Pointer to The GGSW ciphertext
  * @param j 		  The j-th component of the secret key.
  * @param i 		  The i in -m * sk_j / 2^{kappa_tilde * i}.
  *
  * @return A Pointer to the associated Bivariate GLWE.
  */
-VecBiv* ggsw_retrieve_bivglwe(const GGSWParams* params_ggsw, MatBiv* ggsw_mat, int64_t j, int64_t i);
+VecBiv* ggsw_retrieve_bivglwe(GGSWCiphertext* ggsw_ct, int64_t j, int64_t i);
 
 /**
  * @brief Normalizes a GGSW ciphertext.
@@ -175,14 +174,13 @@ void delete_ggsw_dft(GGSWCiphertextDFT* ggsw_dft);
  *
  * The function takes j and i and get the associated bivGLWE.
  *
- * @param params_ggsw A Pointer to the GGSW parameters. Contains `kappa_tilde`.
- * @param ggsw_mat    A Pointer to The GGSW ciphertext's matrix.
+ * @param ggsw_dft_ct    A Pointer to The GGSW ciphertext
  * @param j 		  The j-th component of the secret key.
  * @param i 		  The i in -m * sk_j / 2^{kappa_tilde * i}.
  *
  * @return A Pointer to the associated Bivariate GLWE in the DFT space.
  */
-VecBivDFT* ggsw_retrieve_bivglwe_dft(const GGSWParams* params_ggsw, MatBivDFT* ggsw_mat_dft, int64_t j, int64_t i);
+VecBivDFT* ggsw_retrieve_bivglwe_dft(GGSWCiphertextDFT* ggsw_dft_ct, int64_t j, int64_t i);
 
 /**
  * @brief Normalizes a GGSW ciphertext in the DFT space.

--- a/include/core/glwe/glwe_key.h
+++ b/include/core/glwe/glwe_key.h
@@ -1,6 +1,7 @@
 #ifndef bivGLWE_KEY_H
 #define bivGLWE_KEY_H
 
+#include "bivariate_polynomial.h"
 #include "glwe_ciphertext.h"
 
 //! bivGLWE SECRET KEY STRUCTURES
@@ -13,14 +14,14 @@ typedef struct glwe_secret_key
 {
 	uint64_t N;
 	uint64_t k;
-	PolyUniv** values;
+	PolyUniv* values;
 } GLWESecretKey;
 
 typedef struct glwe_prep_secret_key
 {
 	uint64_t N;
 	uint64_t k;
-	PolyUnivDFT** values;
+	PolyUnivDFT* values;
 } GLWESecretKeyDFT;
 
 //! bivGLWE KEY PART (begin)
@@ -48,6 +49,17 @@ GLWESecretKey* alloc_glwe_secret_key(uint64_t N, uint64_t k);
 int uniform_glwe_secret_key(const MODULE* module, GLWESecretKey* sk, uint64_t nb_bits);
 
 /**
+ * Returns a pointer to the k'th polynomial in the secret key
+ *
+ *
+ * @param sk  The secret key
+ * @param pos The position to retrieve (from 0 to k-1)
+ *
+ * @return    A pointer to the beggining of the pos-th polynomial in the key
+ */
+PolyUniv* glwe_sk_retrieve_vec_pos(GLWESecretKey* sk, uint64_t pos);
+
+/**
  * @brief Delete the secret key.
  *
  * @param sk The secret key.
@@ -64,6 +76,17 @@ void delete_glwe_secret_key(GLWESecretKey* sk);
  * @return GLWESecretKeyDFT*
  */
 GLWESecretKeyDFT* alloc_glwe_secret_key_dft(uint64_t N, uint64_t k);
+
+/**
+ * Returns a pointer to the k'th polynomial in the secret key
+ *
+ *
+ * @param sk  The secret key
+ * @param pos The position to retrieve (from 0 to k-1)
+ *
+ * @return    A pointer to the beggining of the pos-th polynomial in the key
+ */
+PolyUnivDFT* glwe_sk_dft_retrieve_vec_pos(const GLWESecretKeyDFT* sk_dft, uint64_t pos);
 
 /**
  * @brief Delete the secret key that is in the DFT domain.

--- a/src/core/ggsw/ggsw.c
+++ b/src/core/ggsw/ggsw.c
@@ -66,7 +66,8 @@ int ggsw_secret_encrypt(const MODULE* module, GGSWCiphertext* result, const GLWE
 				if (j < params_glwe->k)
 				{
 					// Computes DFT(msg * sk_j)
-					mult_vec_znx_dft(module, m_skj_univ_dft, 1, sk_dft->values[j], 1, m_univ_dft, 1);
+					mult_vec_znx_dft(module, m_skj_univ_dft, 1, glwe_sk_dft_retrieve_vec_pos(sk_dft, j), 1, m_univ_dft,
+					                 1);
 
 					// Computes -DFT(msg * sk_j)
 					for (uint64_t p = 0; p < N; p++) m_skj_univ_dft[p] = -1 * m_skj_univ_dft[p];
@@ -211,7 +212,7 @@ int ggsw_secret_encrypt_dft(const MODULE* module, GGSWCiphertextDFT* result_dft,
 			if (j < k)
 			{
 				// Computes DFT(msg * sk_j)
-				mult_vec_znx_dft(module, m_skj_univ_dft, 1, sk_dft->values[j], 1, m_univ_dft, 1);
+				mult_vec_znx_dft(module, m_skj_univ_dft, 1, glwe_sk_dft_retrieve_vec_pos(sk_dft, j), 1, m_univ_dft, 1);
 
 				// Computes -DFT(msg * sk_j)
 				// TODO: study if accelerable using AVX, do we need it in spqlios?

--- a/src/core/ggsw/ggsw.c
+++ b/src/core/ggsw/ggsw.c
@@ -88,7 +88,7 @@ int ggsw_secret_encrypt(const MODULE* module, GGSWCiphertext* result, const GLWE
 				CHECK_CALL(univ_to_biv(params_glwe, glwe_biv_msg, tmp_sp1), "univ_to_biv failed in compute_phase_ij");
 			}
 			// Get the pointer for the result position
-			VecBiv* glwe_vec       = ggsw_retrieve_bivglwe(params_ggsw, result->mat, j, i);
+			VecBiv* glwe_vec       = ggsw_retrieve_bivglwe(result, j, i);
 			GLWECiphertext glwe_ct = {params_glwe, glwe_vec};
 
 			//Compute: bivGLWE(glwe_biv_msg) into glwe_vec
@@ -237,7 +237,7 @@ int ggsw_secret_encrypt_dft(const MODULE* module, GGSWCiphertextDFT* result_dft,
 			                 poly_biv_size(params_glwe), N);
 
 			// Result destination
-			VecBivDFT* glwe_vec_dft = ggsw_retrieve_bivglwe_dft(params_ggsw, result_dft->mat, j, i);
+			VecBivDFT* glwe_vec_dft = ggsw_retrieve_bivglwe_dft(result_dft, j, i);
 
 			// Finally, mask/encrypt the above result to get a bivGLWE
 

--- a/src/core/ggsw/ggsw_ciphertext.c
+++ b/src/core/ggsw/ggsw_ciphertext.c
@@ -43,15 +43,15 @@ void delete_ggsw(GGSWCiphertext* ggsw)
 }
 
 // TODO: add inline qualifier
-VecBiv* ggsw_retrieve_bivglwe(const GGSWParams* params_ggsw, MatBiv* ggsw_mat, int64_t j, int64_t i)
+VecBiv* ggsw_retrieve_bivglwe(GGSWCiphertext* ggsw_ct, int64_t j, int64_t i)
 {
 	// bivGLWE parameters
-	const GLWEParams* params_glwe = params_ggsw->params_glwe;
+	const GLWEParams* params_glwe = ggsw_ct->params->params_glwe;
 
 	// bivGGSW parameters
-	uint64_t k_tilde = params_ggsw->k_tilde;
+	uint64_t k_tilde = ggsw_ct->params->k_tilde;
 
-	return ggsw_mat + ((i - 1) * (k_tilde + 1) + j) * glwe_coef_number(params_glwe);
+	return ggsw_ct->mat + ((i - 1) * (k_tilde + 1) + j) * glwe_coef_number(params_glwe);
 }
 
 int normalize_ggsw(const MODULE* module, GGSWCiphertext* result, const GGSWCiphertext* ggsw)
@@ -70,7 +70,7 @@ int normalize_ggsw(const MODULE* module, GGSWCiphertext* result, const GGSWCiphe
 		for (uint64_t j = 0; j < ggsw_num_rows_per_pggsw(params_ggsw); j++)
 		{
 			// The pointer to biGLWE(-m * sk_j * Y^i)
-			VecBiv* result_glwe_vec = ggsw_retrieve_bivglwe(params_ggsw, result->mat, j, i);
+			VecBiv* result_glwe_vec = ggsw_retrieve_bivglwe(result, j, i);
 
 			// Normalize the k+1 bivGLWE's elements
 			for (uint64_t t = 0; t < k + 1; t++)
@@ -161,15 +161,15 @@ void delete_ggsw_dft(GGSWCiphertextDFT* ggsw_dft)
 	free(ggsw_dft);
 }
 
-VecBivDFT* ggsw_retrieve_bivglwe_dft(const GGSWParams* params_ggsw, MatBivDFT* ggsw_mat_dft, int64_t j, int64_t i)
+VecBivDFT* ggsw_retrieve_bivglwe_dft(GGSWCiphertextDFT* ggsw_dft_ct, int64_t j, int64_t i)
 {
 	// bivGLWE parameters
-	const GLWEParams* params_glwe = params_ggsw->params_glwe;
+	const GLWEParams* params_glwe = ggsw_dft_ct->params->params_glwe;
 
 	// bivGGSW parameters
-	uint64_t k_tilde = params_ggsw->k_tilde;
+	uint64_t k_tilde = ggsw_dft_ct->params->k_tilde;
 
-	return ggsw_mat_dft + ((i - 1) * (k_tilde + 1) + j) * 2 * glwe_coef_number_dft(params_glwe);
+	return ggsw_dft_ct->mat + ((i - 1) * (k_tilde + 1) + j) * 2 * glwe_coef_number_dft(params_glwe);
 }
 
 int normalize_ggsw_dft(const MODULE* module, GGSWCiphertextDFT* result_dft, const GGSWCiphertextDFT* ggsw_dft)

--- a/src/core/glwe/glwe.c
+++ b/src/core/glwe/glwe.c
@@ -1,5 +1,6 @@
 #include "glwe.h"
 
+#include "glwe_key.h"
 #include "glwe_params.h"
 #include "logger.h"
 #include "rng.h"
@@ -27,8 +28,9 @@ int add_mult(const MODULE* module, const GLWEParams* params, PolyBiv* res, const
 	for (uint64_t j = 0; j < k; j++)
 	{
 		// The j-th component of resp. the secret key and the bivGLWE ciphertext
-		PolyUnivDFT* sk_j_univ_dft = sk_dft->values[j];
-		const PolyBiv* a_j         = glwe + j * N;
+		PolyUnivDFT* sk_j_univ_dft = glwe_sk_dft_retrieve_vec_pos(sk_dft, j);
+
+		const PolyBiv* a_j = glwe + j * N;
 
 		// Computes DFT(sk_j * a_j)
 		pvda_svp_apply_dft(module, as_j_dft, l, sk_j_univ_dft, a_j, l, (k + 1) * N);
@@ -69,7 +71,7 @@ int sub_mult(const MODULE* module, const GLWEParams* params, PolyBiv* res, const
 	for (uint64_t j = 0; j < k; j++)
 	{
 		// The j-th component of resp. the secret key and the bivGLWE ciphertext
-		PolyUnivDFT* sk_j_univ_dft = sk_dft->values[j];
+		PolyUnivDFT* sk_j_univ_dft = glwe_sk_dft_retrieve_vec_pos(sk_dft, j);
 		const PolyBiv* a_j         = ct + j * N;
 
 		// Computes DFT(sk_j * a_j)
@@ -131,7 +133,7 @@ int glwe_secret_masking(const MODULE* module, GLWECiphertext* glwe, const GLWESe
 	for (uint64_t j = 0; j < k; j++)
 	{
 		// The j-th component of the DFT encoding of the secret key
-		PolyUnivDFT* sk_j_univ_dft = sk_dft->values[j];
+		PolyUnivDFT* sk_j_univ_dft = glwe_sk_dft_retrieve_vec_pos(sk_dft, j);
 
 		// Computes DFT(sk_j) * DFT(a_j)
 		pvda_svp_apply_dft(module, as_j_dft, l, sk_j_univ_dft, result + j * N, l, (k + 1) * N);
@@ -195,7 +197,7 @@ int glwe_secret_demasking(const MODULE* module, PolyBiv* res, const GLWESecretKe
 	for (uint64_t j = 0; j < k; j++)
 	{
 		// The j-th component of the secret key in DFT form and the bivGLWE/GLW ciphertext respectively
-		PolyUnivDFT* sk_j_univ_dft = sk_dft->values[j];
+		PolyUnivDFT* sk_j_univ_dft = glwe_sk_dft_retrieve_vec_pos(sk_dft, j);
 		const PolyUniv* a_j        = glwe_vec + j * N;
 
 		// Computes DFT(sk_j * a_j)

--- a/src/core/glwe/glwe_key.c
+++ b/src/core/glwe/glwe_key.c
@@ -1,5 +1,6 @@
 #include "glwe_key.h"
 
+#include <assert.h>
 #include <stdint.h>
 
 #include "logger.h"
@@ -16,18 +17,11 @@ GLWESecretKey* alloc_glwe_secret_key(uint64_t N, uint64_t k)
 	sk->N = N;
 	sk->k = k;
 
-	sk->values = calloc(k, sizeof(double*));
+	sk->values = calloc(N * k, sizeof(double));
 	CHECK_ALLOC(sk->values, "values creation failed in glwe key generation");
-
-	for (j = 0; j < k; j++)
-	{
-		sk->values[j] = calloc(N, sizeof(double));
-		CHECK_ALLOC(sk->values[j], "values elements' calloc failed in alloc_glwe_secret_key");
-	}
 
 	return sk;
 cleanup:
-	for (uint64_t t = 0; t < j; t++) free(sk->values[t]);
 	if (sk) free(sk->values);
 	free(sk);
 	return NULL;
@@ -40,7 +34,8 @@ int uniform_glwe_secret_key(const MODULE* module, GLWESecretKey* sk, uint64_t nb
 	// Uniform random generation of k Zn[X] polynomials.
 	for (uint64_t j = 0; j < sk->k; j++)
 	{
-		CHECK_CALL(uniform_random_vec(N, sk->values[j], 1, N, nb_bits),
+		// TODO: should we forgo the loop and make it a single call to uniform_random_vec?
+		CHECK_CALL(uniform_random_vec(N, glwe_sk_retrieve_vec_pos(sk, j), 1, N, nb_bits),
 		           "random vector generation failed in key generation");
 	}
 
@@ -49,10 +44,15 @@ cleanup:
 	return -1;
 }
 
+PolyUniv* glwe_sk_retrieve_vec_pos(GLWESecretKey* sk, uint64_t pos)
+{
+	assert(pos >= 0 && pos < sk->k);
+	return sk->values + sk->N * pos;
+}
+
 void delete_glwe_secret_key(GLWESecretKey* sk)
 {
 	if (!sk) return;
-	for (uint64_t j = 0; j < sk->k; j++) free(sk->values[j]);
 	free(sk->values);
 	free(sk);
 }
@@ -65,29 +65,27 @@ GLWESecretKeyDFT* alloc_glwe_secret_key_dft(uint64_t N, uint64_t k)
 	sk->N = N;
 	sk->k = k;
 
-	sk->values = malloc(k * sizeof(PolyUnivDFT*));
+	sk->values = malloc(N * k * sizeof(PolyUnivDFT));
 	CHECK_ALLOC(sk->values, "values' malloc failed in alloc_glwe_secret_key_dft");
-
-	for (j = 0; j < k; j++)
-	{
-		sk->values[j] = calloc(N, sizeof(double));
-		CHECK_ALLOC(sk->values[j], "values elements' calloc failed in alloc_glwe_secret_key_dft");
-	}
 
 	return sk;
 cleanup:
 
-	for (uint64_t t = 0; t < j; t++) free(sk->values[t]);
 	if (sk) free(sk->values);
 	free(sk);
 	return NULL;
+}
+
+PolyUnivDFT* glwe_sk_dft_retrieve_vec_pos(const GLWESecretKeyDFT* sk_dft, uint64_t pos)
+{
+	assert(pos >= 0 && pos < sk_dft->k);
+	return sk_dft->values + sk_dft->N * pos;
 }
 
 void delete_glwe_secret_key_dft(GLWESecretKeyDFT* sk_dft)
 {
 	if (!sk_dft) return;
 
-	for (uint64_t j = 0; j < sk_dft->k; j++) free(sk_dft->values[j]);
 	free(sk_dft->values);
 	free(sk_dft);
 }

--- a/src/core/glwe/glwe_transform_key.c
+++ b/src/core/glwe/glwe_transform_key.c
@@ -1,7 +1,11 @@
 #include "glwe_transform_key.h"
 
+#include "glwe_key.h"
+
 void transform_glwe_secret_key_not_dft_to_dft(const MODULE* module, GLWESecretKeyDFT* result_dft,
                                               const GLWESecretKey* sk)
 {
-	for (uint64_t j = 0; j < sk->k; j++) pvda_vec_znx_dft(module, result_dft->values[j], 1, sk->values[j], 1, sk->N);
+	for (uint64_t j = 0; j < sk->k; j++)
+		pvda_vec_znx_dft(module, glwe_sk_dft_retrieve_vec_pos(result_dft, j), 1, glwe_sk_retrieve_vec_pos(sk, j), 1,
+		                 sk->N);
 }

--- a/tests/unit/core/ggsw/test_ggsw_ciphertext.c
+++ b/tests/unit/core/ggsw/test_ggsw_ciphertext.c
@@ -99,7 +99,7 @@ Test(ggsw_Sj_Yti, basic)
 	for (uint64_t i = 1; i < ggsw_num_pggsw(params_ggsw); i++)
 		for (uint64_t j = 0; j < K_TILDEBASE + 1; j++)
 		{
-			VecBiv* ct_mat_ij = ggsw_retrieve_bivglwe(params_ggsw, ggsw->mat, j, i);
+			VecBiv* ct_mat_ij = ggsw_retrieve_bivglwe(ggsw, j, i);
 
 			// Modify the two firsts coefficients of biGLWE(-m * sk_j / 2^{kappa_tilde * i}).
 			ct_mat_ij[0] = 1;
@@ -214,8 +214,8 @@ Test(const_mult_ggsw, without_normalization)
 	for (uint64_t ii = 1; ii <= ggsw_num_pggsw(params_ggsw); ii++)
 		for (uint64_t jj = 0; jj < K_TILDEBASE + 1; jj++)
 		{
-			VecBiv* ct_mat_ii_jj  = ggsw_retrieve_bivglwe(params_ggsw, ggsw->mat, jj, ii);
-			VecBiv* res_mat_ii_jj = ggsw_retrieve_bivglwe(params_ggsw, product_computed->mat, jj, ii);
+			VecBiv* ct_mat_ii_jj  = ggsw_retrieve_bivglwe(ggsw, jj, ii);
+			VecBiv* res_mat_ii_jj = ggsw_retrieve_bivglwe(product_computed, jj, ii);
 			for (uint64_t j = 0; j < KBASE + 1; j++)
 				for (uint64_t p = 0; p < NBASE; p++)
 					for (uint64_t i = 1; i <= LBASE; i++)
@@ -275,8 +275,8 @@ Test(const_mult_ggsw, with_normalization)
 	for (uint64_t ii = 1; ii <= ggsw_num_pggsw(params_ggsw); ii++)
 		for (uint64_t jj = 0; jj < K_TILDEBASE + 1; jj++)
 		{
-			VecBiv* ct_mat_ii_jj  = ggsw_retrieve_bivglwe(params_ggsw, ggsw->mat, jj, ii);
-			VecBiv* res_mat_ii_jj = ggsw_retrieve_bivglwe(params_ggsw, product_computed->mat, jj, ii);
+			VecBiv* ct_mat_ii_jj  = ggsw_retrieve_bivglwe(ggsw, jj, ii);
+			VecBiv* res_mat_ii_jj = ggsw_retrieve_bivglwe(product_computed, jj, ii);
 
 			for (uint64_t j = 0; j < KBASE + 1; j++)
 				for (uint64_t p = 0; p < NBASE; p++)
@@ -373,7 +373,7 @@ Test(ggsw_Sj_Yti_dft, basic)
 	for (uint64_t i = 1; i < ggsw_num_pggsw(params_ggsw); i++)
 		for (uint64_t j = 0; j < K_TILDEBASE + 1; j++)
 		{
-			VecBivDFT* ct_mat_ij = ggsw_retrieve_bivglwe_dft(params_ggsw, ggsw_dft->mat, j, i);
+			VecBivDFT* ct_mat_ij = ggsw_retrieve_bivglwe_dft(ggsw_dft, j, i);
 
 			// Modify the two firsts coefficients of biGLWE(-m * sk_j / 2^{kappa_tilde * i}).
 			ct_mat_ij[0] = 0.1;
@@ -475,8 +475,8 @@ Test(const_mult_ggsw_dft, without_normalization)
 	GGSWCiphertextDFT* ggsw_dft          = new_ggsw_dft(params_ggsw);
 	GGSWCiphertextDFT* prod_computed_dft = new_ggsw_dft(params_ggsw);
 	PolyUniv* u                          = malloc(NBASE * sizeof(double));
-	MatBiv* ggsw_mat                     = malloc(ggsw_bytes(params_ggsw));
-	MatBiv* prod_computed_mat            = malloc(ggsw_bytes(params_ggsw));
+	GGSWCiphertext* ggsw_ct              = new_ggsw(params_ggsw);
+	GGSWCiphertext* prod_comp            = new_ggsw(params_ggsw);
 
 	// Draws uniformly the Zn[X] polynomial in the DFT domain
 	uniform_random_vec_znx_dft(module, u_dft, 1, KAPPABASE - 1);
@@ -489,16 +489,15 @@ Test(const_mult_ggsw_dft, without_normalization)
 
 	// Computes the matrix of u_dft, ggsw_dft and prod_computed_dft out of the DFT domain
 	pvda_vec_znx_idft(module, u, 1, u_dft, 1);
-	pvda_vec_znx_idft(module, ggsw_mat, ggsw_size(params_ggsw), ggsw_dft->mat, ggsw_size(params_ggsw));
-	pvda_vec_znx_idft(module, prod_computed_mat, ggsw_size(params_ggsw), prod_computed_dft->mat,
-	                  ggsw_size(params_ggsw));
+	pvda_vec_znx_idft(module, ggsw_ct->mat, ggsw_size(params_ggsw), ggsw_dft->mat, ggsw_size(params_ggsw));
+	pvda_vec_znx_idft(module, prod_comp->mat, ggsw_size(params_ggsw), prod_computed_dft->mat, ggsw_size(params_ggsw));
 
 	// Asserts prod_computed_dft = DFT(u) * DFT(ggsw)
 	for (uint64_t ii = 1; ii <= ggsw_num_pggsw(params_ggsw); ii++)
 		for (uint64_t jj = 0; jj < K_TILDEBASE + 1; jj++)
 		{
-			VecBiv* ct_mat_ii_jj  = ggsw_retrieve_bivglwe(params_ggsw, ggsw_mat, jj, ii);
-			VecBiv* res_mat_ii_jj = ggsw_retrieve_bivglwe(params_ggsw, prod_computed_mat, jj, ii);
+			VecBiv* ct_mat_ii_jj  = ggsw_retrieve_bivglwe(ggsw_ct, jj, ii);
+			VecBiv* res_mat_ii_jj = ggsw_retrieve_bivglwe(prod_comp, jj, ii);
 			for (uint64_t j = 0; j < KBASE + 1; j++)
 				for (uint64_t p = 0; p < NBASE; p++)
 					for (uint64_t i = 1; i <= LBASE; i++)
@@ -523,8 +522,8 @@ Test(const_mult_ggsw_dft, without_normalization)
 	// Clean up
 	free(u);
 	free(u_dft);
-	free(ggsw_mat);
-	free(prod_computed_mat);
+	delete_ggsw(ggsw_ct);
+	delete_ggsw(prod_comp);
 	delete_ggsw_dft(ggsw_dft);
 	delete_ggsw_dft(prod_computed_dft);
 	delete_ggsw_params(params_ggsw);
@@ -544,8 +543,8 @@ Test(const_mult_ggsw_dft, with_normalization)
 	GGSWCiphertextDFT* ggsw_dft          = new_ggsw_dft(params_ggsw);
 	GGSWCiphertextDFT* prod_computed_dft = new_ggsw_dft(params_ggsw);
 	PolyUniv* u                          = malloc(NBASE * sizeof(double));
-	MatBiv* ggsw_mat                     = malloc(ggsw_bytes(params_ggsw));
-	MatBiv* prod_computed_mat            = malloc(ggsw_bytes(params_ggsw));
+	GGSWCiphertext* ggsw_ct              = new_ggsw(params_ggsw);
+	GGSWCiphertext* prod_comp            = new_ggsw(params_ggsw);
 
 	// Draws uniformly the Zn[X] polynomial in the DFT domain
 	uniform_random_vec_znx_dft(module, u_dft, 1, KAPPABASE - 1);
@@ -558,15 +557,14 @@ Test(const_mult_ggsw_dft, with_normalization)
 
 	// Computes the matrix of u_dft, ggsw_dft and prod_computed_dft out of the DFT domain
 	pvda_vec_znx_idft(module, u, 1, u_dft, 1);
-	pvda_vec_znx_idft(module, ggsw_mat, ggsw_size(params_ggsw), ggsw_dft->mat, ggsw_size(params_ggsw));
-	pvda_vec_znx_idft(module, prod_computed_mat, ggsw_size(params_ggsw), prod_computed_dft->mat,
-	                  ggsw_size(params_ggsw));
+	pvda_vec_znx_idft(module, ggsw_ct->mat, ggsw_size(params_ggsw), ggsw_dft->mat, ggsw_size(params_ggsw));
+	pvda_vec_znx_idft(module, prod_comp->mat, ggsw_size(params_ggsw), prod_computed_dft->mat, ggsw_size(params_ggsw));
 
 	for (uint64_t ii = 1; ii <= ggsw_num_pggsw(params_ggsw); ii++)
 		for (uint64_t jj = 0; jj < K_TILDEBASE + 1; jj++)
 		{
-			VecBiv* ct_mat_ii_jj  = ggsw_retrieve_bivglwe(params_ggsw, ggsw_mat, jj, ii);
-			VecBiv* res_mat_ii_jj = ggsw_retrieve_bivglwe(params_ggsw, prod_computed_mat, jj, ii);
+			VecBiv* ct_mat_ii_jj  = ggsw_retrieve_bivglwe(ggsw_ct, jj, ii);
+			VecBiv* res_mat_ii_jj = ggsw_retrieve_bivglwe(prod_comp, jj, ii);
 			for (uint64_t j = 0; j < KBASE + 1; j++)
 				for (uint64_t p = 0; p < NBASE; p++)
 				{
@@ -604,8 +602,8 @@ Test(const_mult_ggsw_dft, with_normalization)
 	// Clean up
 	free(u);
 	free(u_dft);
-	free(ggsw_mat);
-	free(prod_computed_mat);
+	delete_ggsw(ggsw_ct);
+	delete_ggsw(prod_comp);
 	delete_ggsw_dft(ggsw_dft);
 	delete_ggsw_dft(prod_computed_dft);
 	delete_ggsw_params(params_ggsw);

--- a/tests/unit/core/ggsw/test_ggsw_encrypt.c
+++ b/tests/unit/core/ggsw/test_ggsw_encrypt.c
@@ -88,7 +88,7 @@ Test(ggsw_secret_encrypt, works)
 			memset(phase_univ_RnX, 0, poly_univ_bytes(params_glwe));
 
 			// Computes the phase = -m * sk_j / 2^{kappa_tilde * i}) + err
-			GLWECiphertext glwe_ct = {params_glwe, ggsw_retrieve_bivglwe(params_ggsw, ggsw->mat, j, i)};
+			GLWECiphertext glwe_ct = {params_glwe, ggsw_retrieve_bivglwe(ggsw, j, i)};
 			glwe_secret_demasking(module, phase_computed, sk_dft, &glwe_ct);
 			biv_to_univ(params_glwe, phase_computed_univ_RnX, phase_computed);
 
@@ -258,7 +258,7 @@ Test(ggsw_secret_encrypt_dft, works)
 			memset(phase_univ_RnX, 0, poly_univ_bytes(params_glwe));
 
 			// Computes the phase = -m * sk_j / 2^{kappa_tilde * i}) + err
-			GLWECiphertextDFT glwe_dft_ct = {params_glwe, ggsw_retrieve_bivglwe_dft(params_ggsw, ggsw_dft->mat, j, i)};
+			GLWECiphertextDFT glwe_dft_ct = {params_glwe, ggsw_retrieve_bivglwe_dft(ggsw_dft, j, i)};
 			glwe_secret_demasking_dft(module, phase_computed, sk_dft, &glwe_dft_ct);
 
 			// Computes the phase = -m * sk_j / 2^{kappa_tilde * i} + err in RnX

--- a/tests/unit/core/ggsw/test_ggsw_encrypt.c
+++ b/tests/unit/core/ggsw/test_ggsw_encrypt.c
@@ -93,7 +93,7 @@ Test(ggsw_secret_encrypt, works)
 			biv_to_univ(params_glwe, phase_computed_univ_RnX, phase_computed);
 
 			// Computes DFT(m * sk_j)
-			mult_vec_znx_dft(module, m_skj_univ_dft, 1, sk_dft->values[j], 1, m_univ_dft, 1);
+			mult_vec_znx_dft(module, m_skj_univ_dft, 1, glwe_sk_dft_retrieve_vec_pos(sk_dft, j), 1, m_univ_dft, 1);
 
 			// Computes DFT(-m * sk_j)
 			// TODO: znx negate
@@ -266,7 +266,7 @@ Test(ggsw_secret_encrypt_dft, works)
 
 			//! Computes by hand the phase = -m * sk_j / 2^{kappa_tilde*i}
 			// Computes DFT(m * sk_j)
-			mult_vec_znx_dft(module, m_skj_univ_dft, 1, sk_dft->values[j], 1, m_univ_dft, 1);
+			mult_vec_znx_dft(module, m_skj_univ_dft, 1, glwe_sk_dft_retrieve_vec_pos(sk_dft, j), 1, m_univ_dft, 1);
 
 			// Computes -m * sk_j
 			for (uint64_t p = 0; p < NBASE; p++)

--- a/tests/unit/core/ggsw/test_ggsw_external_product.c
+++ b/tests/unit/core/ggsw/test_ggsw_external_product.c
@@ -72,7 +72,8 @@ Test(ggsw_external_product, without_error)
 	double* um_univ_RnX               = calloc(NBASE, sizeof(double));
 
 	// Define sk_ggsw = (1, 0, ... , 0)
-	sk_ggsw->values[0][0] = 1;
+	// TODO: WHY?
+	sk_ggsw->values[0] = 1;
 
 	// Computes the bivGGSW secret key out of the DFT domain
 	transform_glwe_secret_key_not_dft_to_dft(module, sk_glwe_dft, sk_ggsw);
@@ -181,8 +182,9 @@ Test(ggsw_external_product_dft, without_error)
 	PolyBiv* um                       = malloc(poly_biv_bytes(params_glwe));
 	PolyUnivRnX* um_univ_RnX          = calloc(NBASE, sizeof(double));
 
-	// Define sk_ggsw = (1, 0, ... , 0)
-	sk_ggsw->values[0][0] = 2;
+	// Define sk_ggsw = (2, 0, ... , 0)
+	// TODO: why?
+	sk_ggsw->values[0] = 2;
 
 	// Computes the bivGGSW secret key out of the DFT domain
 	transform_glwe_secret_key_not_dft_to_dft(module, sk_glwe_dft, sk_ggsw);


### PR DESCRIPTION
Changed the way that keys are stored in memory, from array of pointers to each polynomial to a simple flattened array with all the positions. 

This could allow us to use spqlios functions on the secret keys in the future, instead of having to iterate over each sk vector position. See #17 