### PR TITLE
Refactored key storage to use flattened memory

### DIFF
--- a/include/core/glwe/glwe_key.h
+++ b/include/core/glwe/glwe_key.h
@@ -1,6 +1,7 @@
 #ifndef bivGLWE_KEY_H
 #define bivGLWE_KEY_H
 
+#include "bivariate_polynomial.h"
 #include "glwe_ciphertext.h"
 
 //! bivGLWE SECRET KEY STRUCTURES
@@ -13,14 +14,14 @@ typedef struct glwe_secret_key
 {
 	uint64_t N;
 	uint64_t k;
-	PolyUniv** values;
+	PolyUniv* values;
 } GLWESecretKey;
 
 typedef struct glwe_prep_secret_key
 {
 	uint64_t N;
 	uint64_t k;
-	PolyUnivDFT** values;
+	PolyUnivDFT* values;
 } GLWESecretKeyDFT;
 
 //! bivGLWE KEY PART (begin)
@@ -48,6 +49,17 @@ GLWESecretKey* alloc_glwe_secret_key(uint64_t N, uint64_t k);
 int uniform_glwe_secret_key(const MODULE* module, GLWESecretKey* sk, uint64_t nb_bits);
 
 /**
+ * Returns a pointer to the k'th polynomial in the secret key
+ *
+ *
+ * @param sk  The secret key
+ * @param pos The position to retrieve (from 0 to k-1)
+ *
+ * @return    A pointer to the beggining of the pos-th polynomial in the key
+ */
+PolyUniv* glwe_sk_retrieve_vec_pos(GLWESecretKey* sk, uint64_t pos);
+
+/**
  * @brief Delete the secret key.
  *
  * @param sk The secret key.
@@ -64,6 +76,17 @@ void delete_glwe_secret_key(GLWESecretKey* sk);
  * @return GLWESecretKeyDFT*
  */
 GLWESecretKeyDFT* alloc_glwe_secret_key_dft(uint64_t N, uint64_t k);
+
+/**
+ * Returns a pointer to the k'th polynomial in the secret key
+ *
+ *
+ * @param sk  The secret key
+ * @param pos The position to retrieve (from 0 to k-1)
+ *
+ * @return    A pointer to the beggining of the pos-th polynomial in the key
+ */
+PolyUnivDFT* glwe_sk_dft_retrieve_vec_pos(const GLWESecretKeyDFT* sk_dft, uint64_t pos);
 
 /**
  * @brief Delete the secret key that is in the DFT domain.

--- a/include/core/glwe/glwe_key.h
+++ b/include/core/glwe/glwe_key.h
@@ -57,7 +57,7 @@ int uniform_glwe_secret_key(const MODULE* module, GLWESecretKey* sk, uint64_t nb
  *
  * @return    A pointer to the beggining of the pos-th polynomial in the key
  */
-PolyUniv* glwe_sk_retrieve_vec_pos(GLWESecretKey* sk, uint64_t pos);
+PolyUniv* glwe_sk_extract_poly(GLWESecretKey* sk, uint64_t pos);
 
 /**
  * @brief Delete the secret key.
@@ -86,7 +86,7 @@ GLWESecretKeyDFT* alloc_glwe_secret_key_dft(uint64_t N, uint64_t k);
  *
  * @return    A pointer to the beggining of the pos-th polynomial in the key
  */
-PolyUnivDFT* glwe_sk_dft_retrieve_vec_pos(const GLWESecretKeyDFT* sk_dft, uint64_t pos);
+PolyUnivDFT* glwe_sk_extract_poly_dft(const GLWESecretKeyDFT* sk_dft, uint64_t pos);
 
 /**
  * @brief Delete the secret key that is in the DFT domain.

--- a/src/core/ggsw/ggsw.c
+++ b/src/core/ggsw/ggsw.c
@@ -66,7 +66,8 @@ int ggsw_secret_encrypt(const MODULE* module, GGSWCiphertext* result, const GLWE
 				if (j < params_glwe->k)
 				{
 					// Computes DFT(msg * sk_j)
-					mult_vec_znx_dft(module, m_skj_univ_dft, 1, sk_dft->values[j], 1, m_univ_dft, 1);
+					mult_vec_znx_dft(module, m_skj_univ_dft, 1, glwe_sk_dft_retrieve_vec_pos(sk_dft, j), 1, m_univ_dft,
+					                 1);
 
 					// Computes -DFT(msg * sk_j)
 					for (uint64_t p = 0; p < N; p++) m_skj_univ_dft[p] = -1 * m_skj_univ_dft[p];
@@ -211,7 +212,7 @@ int ggsw_secret_encrypt_dft(const MODULE* module, GGSWCiphertextDFT* result_dft,
 			if (j < k)
 			{
 				// Computes DFT(msg * sk_j)
-				mult_vec_znx_dft(module, m_skj_univ_dft, 1, sk_dft->values[j], 1, m_univ_dft, 1);
+				mult_vec_znx_dft(module, m_skj_univ_dft, 1, glwe_sk_dft_retrieve_vec_pos(sk_dft, j), 1, m_univ_dft, 1);
 
 				// Computes -DFT(msg * sk_j)
 				// TODO: study if accelerable using AVX, do we need it in spqlios?

--- a/src/core/ggsw/ggsw.c
+++ b/src/core/ggsw/ggsw.c
@@ -66,8 +66,7 @@ int ggsw_secret_encrypt(const MODULE* module, GGSWCiphertext* result, const GLWE
 				if (j < params_glwe->k)
 				{
 					// Computes DFT(msg * sk_j)
-					mult_vec_znx_dft(module, m_skj_univ_dft, 1, glwe_sk_dft_retrieve_vec_pos(sk_dft, j), 1, m_univ_dft,
-					                 1);
+					mult_vec_znx_dft(module, m_skj_univ_dft, 1, glwe_sk_extract_poly_dft(sk_dft, j), 1, m_univ_dft, 1);
 
 					// Computes -DFT(msg * sk_j)
 					for (uint64_t p = 0; p < N; p++) m_skj_univ_dft[p] = -1 * m_skj_univ_dft[p];
@@ -212,7 +211,7 @@ int ggsw_secret_encrypt_dft(const MODULE* module, GGSWCiphertextDFT* result_dft,
 			if (j < k)
 			{
 				// Computes DFT(msg * sk_j)
-				mult_vec_znx_dft(module, m_skj_univ_dft, 1, glwe_sk_dft_retrieve_vec_pos(sk_dft, j), 1, m_univ_dft, 1);
+				mult_vec_znx_dft(module, m_skj_univ_dft, 1, glwe_sk_extract_poly_dft(sk_dft, j), 1, m_univ_dft, 1);
 
 				// Computes -DFT(msg * sk_j)
 				// TODO: study if accelerable using AVX, do we need it in spqlios?

--- a/src/core/glwe/glwe.c
+++ b/src/core/glwe/glwe.c
@@ -1,5 +1,6 @@
 #include "glwe.h"
 
+#include "glwe_key.h"
 #include "glwe_params.h"
 #include "logger.h"
 #include "rng.h"
@@ -27,8 +28,9 @@ int add_mult(const MODULE* module, const GLWEParams* params, PolyBiv* res, const
 	for (uint64_t j = 0; j < k; j++)
 	{
 		// The j-th component of resp. the secret key and the bivGLWE ciphertext
-		PolyUnivDFT* sk_j_univ_dft = sk_dft->values[j];
-		const PolyBiv* a_j         = glwe + j * N;
+		PolyUnivDFT* sk_j_univ_dft = glwe_sk_dft_retrieve_vec_pos(sk_dft, j);
+
+		const PolyBiv* a_j = glwe + j * N;
 
 		// Computes DFT(sk_j * a_j)
 		pvda_svp_apply_dft(module, as_j_dft, l, sk_j_univ_dft, a_j, l, (k + 1) * N);
@@ -69,7 +71,7 @@ int sub_mult(const MODULE* module, const GLWEParams* params, PolyBiv* res, const
 	for (uint64_t j = 0; j < k; j++)
 	{
 		// The j-th component of resp. the secret key and the bivGLWE ciphertext
-		PolyUnivDFT* sk_j_univ_dft = sk_dft->values[j];
+		PolyUnivDFT* sk_j_univ_dft = glwe_sk_dft_retrieve_vec_pos(sk_dft, j);
 		const PolyBiv* a_j         = ct + j * N;
 
 		// Computes DFT(sk_j * a_j)
@@ -131,7 +133,7 @@ int glwe_secret_masking(const MODULE* module, GLWECiphertext* glwe, const GLWESe
 	for (uint64_t j = 0; j < k; j++)
 	{
 		// The j-th component of the DFT encoding of the secret key
-		PolyUnivDFT* sk_j_univ_dft = sk_dft->values[j];
+		PolyUnivDFT* sk_j_univ_dft = glwe_sk_dft_retrieve_vec_pos(sk_dft, j);
 
 		// Computes DFT(sk_j) * DFT(a_j)
 		pvda_svp_apply_dft(module, as_j_dft, l, sk_j_univ_dft, result + j * N, l, (k + 1) * N);
@@ -195,7 +197,7 @@ int glwe_secret_demasking(const MODULE* module, PolyBiv* res, const GLWESecretKe
 	for (uint64_t j = 0; j < k; j++)
 	{
 		// The j-th component of the secret key in DFT form and the bivGLWE/GLW ciphertext respectively
-		PolyUnivDFT* sk_j_univ_dft = sk_dft->values[j];
+		PolyUnivDFT* sk_j_univ_dft = glwe_sk_dft_retrieve_vec_pos(sk_dft, j);
 		const PolyUniv* a_j        = glwe_vec + j * N;
 
 		// Computes DFT(sk_j * a_j)

--- a/src/core/glwe/glwe.c
+++ b/src/core/glwe/glwe.c
@@ -28,7 +28,7 @@ int add_mult(const MODULE* module, const GLWEParams* params, PolyBiv* res, const
 	for (uint64_t j = 0; j < k; j++)
 	{
 		// The j-th component of resp. the secret key and the bivGLWE ciphertext
-		PolyUnivDFT* sk_j_univ_dft = glwe_sk_dft_retrieve_vec_pos(sk_dft, j);
+		PolyUnivDFT* sk_j_univ_dft = glwe_sk_extract_poly_dft(sk_dft, j);
 
 		const PolyBiv* a_j = glwe + j * N;
 
@@ -71,7 +71,7 @@ int sub_mult(const MODULE* module, const GLWEParams* params, PolyBiv* res, const
 	for (uint64_t j = 0; j < k; j++)
 	{
 		// The j-th component of resp. the secret key and the bivGLWE ciphertext
-		PolyUnivDFT* sk_j_univ_dft = glwe_sk_dft_retrieve_vec_pos(sk_dft, j);
+		PolyUnivDFT* sk_j_univ_dft = glwe_sk_extract_poly_dft(sk_dft, j);
 		const PolyBiv* a_j         = ct + j * N;
 
 		// Computes DFT(sk_j * a_j)
@@ -133,7 +133,7 @@ int glwe_secret_masking(const MODULE* module, GLWECiphertext* glwe, const GLWESe
 	for (uint64_t j = 0; j < k; j++)
 	{
 		// The j-th component of the DFT encoding of the secret key
-		PolyUnivDFT* sk_j_univ_dft = glwe_sk_dft_retrieve_vec_pos(sk_dft, j);
+		PolyUnivDFT* sk_j_univ_dft = glwe_sk_extract_poly_dft(sk_dft, j);
 
 		// Computes DFT(sk_j) * DFT(a_j)
 		pvda_svp_apply_dft(module, as_j_dft, l, sk_j_univ_dft, result + j * N, l, (k + 1) * N);
@@ -197,7 +197,7 @@ int glwe_secret_demasking(const MODULE* module, PolyBiv* res, const GLWESecretKe
 	for (uint64_t j = 0; j < k; j++)
 	{
 		// The j-th component of the secret key in DFT form and the bivGLWE/GLW ciphertext respectively
-		PolyUnivDFT* sk_j_univ_dft = glwe_sk_dft_retrieve_vec_pos(sk_dft, j);
+		PolyUnivDFT* sk_j_univ_dft = glwe_sk_extract_poly_dft(sk_dft, j);
 		const PolyUniv* a_j        = glwe_vec + j * N;
 
 		// Computes DFT(sk_j * a_j)

--- a/src/core/glwe/glwe_key.c
+++ b/src/core/glwe/glwe_key.c
@@ -35,7 +35,7 @@ int uniform_glwe_secret_key(const MODULE* module, GLWESecretKey* sk, uint64_t nb
 	for (uint64_t j = 0; j < sk->k; j++)
 	{
 		// TODO: should we forgo the loop and make it a single call to uniform_random_vec?
-		CHECK_CALL(uniform_random_vec(N, glwe_sk_retrieve_vec_pos(sk, j), 1, N, nb_bits),
+		CHECK_CALL(uniform_random_vec(N, glwe_sk_extract_poly(sk, j), 1, N, nb_bits),
 		           "random vector generation failed in key generation");
 	}
 
@@ -44,7 +44,7 @@ cleanup:
 	return -1;
 }
 
-PolyUniv* glwe_sk_retrieve_vec_pos(GLWESecretKey* sk, uint64_t pos)
+PolyUniv* glwe_sk_extract_poly(GLWESecretKey* sk, uint64_t pos)
 {
 	assert(pos >= 0 && pos < sk->k);
 	return sk->values + sk->N * pos;
@@ -76,7 +76,7 @@ cleanup:
 	return NULL;
 }
 
-PolyUnivDFT* glwe_sk_dft_retrieve_vec_pos(const GLWESecretKeyDFT* sk_dft, uint64_t pos)
+PolyUnivDFT* glwe_sk_extract_poly_dft(const GLWESecretKeyDFT* sk_dft, uint64_t pos)
 {
 	assert(pos >= 0 && pos < sk_dft->k);
 	return sk_dft->values + sk_dft->N * pos;

--- a/src/core/glwe/glwe_key.c
+++ b/src/core/glwe/glwe_key.c
@@ -1,5 +1,6 @@
 #include "glwe_key.h"
 
+#include <assert.h>
 #include <stdint.h>
 
 #include "logger.h"
@@ -16,18 +17,11 @@ GLWESecretKey* alloc_glwe_secret_key(uint64_t N, uint64_t k)
 	sk->N = N;
 	sk->k = k;
 
-	sk->values = calloc(k, sizeof(double*));
+	sk->values = calloc(N * k, sizeof(double));
 	CHECK_ALLOC(sk->values, "values creation failed in glwe key generation");
-
-	for (j = 0; j < k; j++)
-	{
-		sk->values[j] = calloc(N, sizeof(double));
-		CHECK_ALLOC(sk->values[j], "values elements' calloc failed in alloc_glwe_secret_key");
-	}
 
 	return sk;
 cleanup:
-	for (uint64_t t = 0; t < j; t++) free(sk->values[t]);
 	if (sk) free(sk->values);
 	free(sk);
 	return NULL;
@@ -40,7 +34,8 @@ int uniform_glwe_secret_key(const MODULE* module, GLWESecretKey* sk, uint64_t nb
 	// Uniform random generation of k Zn[X] polynomials.
 	for (uint64_t j = 0; j < sk->k; j++)
 	{
-		CHECK_CALL(uniform_random_vec(N, sk->values[j], 1, N, nb_bits),
+		// TODO: should we forgo the loop and make it a single call to uniform_random_vec?
+		CHECK_CALL(uniform_random_vec(N, glwe_sk_retrieve_vec_pos(sk, j), 1, N, nb_bits),
 		           "random vector generation failed in key generation");
 	}
 
@@ -49,10 +44,15 @@ cleanup:
 	return -1;
 }
 
+PolyUniv* glwe_sk_retrieve_vec_pos(GLWESecretKey* sk, uint64_t pos)
+{
+	assert(pos >= 0 && pos < sk->k);
+	return sk->values + sk->N * pos;
+}
+
 void delete_glwe_secret_key(GLWESecretKey* sk)
 {
 	if (!sk) return;
-	for (uint64_t j = 0; j < sk->k; j++) free(sk->values[j]);
 	free(sk->values);
 	free(sk);
 }
@@ -65,29 +65,27 @@ GLWESecretKeyDFT* alloc_glwe_secret_key_dft(uint64_t N, uint64_t k)
 	sk->N = N;
 	sk->k = k;
 
-	sk->values = malloc(k * sizeof(PolyUnivDFT*));
+	sk->values = malloc(N * k * sizeof(PolyUnivDFT));
 	CHECK_ALLOC(sk->values, "values' malloc failed in alloc_glwe_secret_key_dft");
-
-	for (j = 0; j < k; j++)
-	{
-		sk->values[j] = calloc(N, sizeof(double));
-		CHECK_ALLOC(sk->values[j], "values elements' calloc failed in alloc_glwe_secret_key_dft");
-	}
 
 	return sk;
 cleanup:
 
-	for (uint64_t t = 0; t < j; t++) free(sk->values[t]);
 	if (sk) free(sk->values);
 	free(sk);
 	return NULL;
+}
+
+PolyUnivDFT* glwe_sk_dft_retrieve_vec_pos(const GLWESecretKeyDFT* sk_dft, uint64_t pos)
+{
+	assert(pos >= 0 && pos < sk_dft->k);
+	return sk_dft->values + sk_dft->N * pos;
 }
 
 void delete_glwe_secret_key_dft(GLWESecretKeyDFT* sk_dft)
 {
 	if (!sk_dft) return;
 
-	for (uint64_t j = 0; j < sk_dft->k; j++) free(sk_dft->values[j]);
 	free(sk_dft->values);
 	free(sk_dft);
 }

--- a/src/core/glwe/glwe_transform_key.c
+++ b/src/core/glwe/glwe_transform_key.c
@@ -6,6 +6,5 @@ void transform_glwe_secret_key_not_dft_to_dft(const MODULE* module, GLWESecretKe
                                               const GLWESecretKey* sk)
 {
 	for (uint64_t j = 0; j < sk->k; j++)
-		pvda_vec_znx_dft(module, glwe_sk_dft_retrieve_vec_pos(result_dft, j), 1, glwe_sk_retrieve_vec_pos(sk, j), 1,
-		                 sk->N);
+		pvda_vec_znx_dft(module, glwe_sk_extract_poly_dft(result_dft, j), 1, glwe_sk_extract_poly(sk, j), 1, sk->N);
 }

--- a/src/core/glwe/glwe_transform_key.c
+++ b/src/core/glwe/glwe_transform_key.c
@@ -1,7 +1,11 @@
 #include "glwe_transform_key.h"
 
+#include "glwe_key.h"
+
 void transform_glwe_secret_key_not_dft_to_dft(const MODULE* module, GLWESecretKeyDFT* result_dft,
                                               const GLWESecretKey* sk)
 {
-	for (uint64_t j = 0; j < sk->k; j++) pvda_vec_znx_dft(module, result_dft->values[j], 1, sk->values[j], 1, sk->N);
+	for (uint64_t j = 0; j < sk->k; j++)
+		pvda_vec_znx_dft(module, glwe_sk_dft_retrieve_vec_pos(result_dft, j), 1, glwe_sk_retrieve_vec_pos(sk, j), 1,
+		                 sk->N);
 }

--- a/tests/unit/core/ggsw/test_ggsw_encrypt.c
+++ b/tests/unit/core/ggsw/test_ggsw_encrypt.c
@@ -93,7 +93,7 @@ Test(ggsw_secret_encrypt, works)
 			biv_to_univ(params_glwe, phase_computed_univ_RnX, phase_computed);
 
 			// Computes DFT(m * sk_j)
-			mult_vec_znx_dft(module, m_skj_univ_dft, 1, glwe_sk_dft_retrieve_vec_pos(sk_dft, j), 1, m_univ_dft, 1);
+			mult_vec_znx_dft(module, m_skj_univ_dft, 1, glwe_sk_extract_poly_dft(sk_dft, j), 1, m_univ_dft, 1);
 
 			// Computes DFT(-m * sk_j)
 			// TODO: znx negate
@@ -266,7 +266,7 @@ Test(ggsw_secret_encrypt_dft, works)
 
 			//! Computes by hand the phase = -m * sk_j / 2^{kappa_tilde*i}
 			// Computes DFT(m * sk_j)
-			mult_vec_znx_dft(module, m_skj_univ_dft, 1, glwe_sk_dft_retrieve_vec_pos(sk_dft, j), 1, m_univ_dft, 1);
+			mult_vec_znx_dft(module, m_skj_univ_dft, 1, glwe_sk_extract_poly_dft(sk_dft, j), 1, m_univ_dft, 1);
 
 			// Computes -m * sk_j
 			for (uint64_t p = 0; p < NBASE; p++)

--- a/tests/unit/core/ggsw/test_ggsw_encrypt.c
+++ b/tests/unit/core/ggsw/test_ggsw_encrypt.c
@@ -93,7 +93,7 @@ Test(ggsw_secret_encrypt, works)
 			biv_to_univ(params_glwe, phase_computed_univ_RnX, phase_computed);
 
 			// Computes DFT(m * sk_j)
-			mult_vec_znx_dft(module, m_skj_univ_dft, 1, sk_dft->values[j], 1, m_univ_dft, 1);
+			mult_vec_znx_dft(module, m_skj_univ_dft, 1, glwe_sk_dft_retrieve_vec_pos(sk_dft, j), 1, m_univ_dft, 1);
 
 			// Computes DFT(-m * sk_j)
 			// TODO: znx negate
@@ -266,7 +266,7 @@ Test(ggsw_secret_encrypt_dft, works)
 
 			//! Computes by hand the phase = -m * sk_j / 2^{kappa_tilde*i}
 			// Computes DFT(m * sk_j)
-			mult_vec_znx_dft(module, m_skj_univ_dft, 1, sk_dft->values[j], 1, m_univ_dft, 1);
+			mult_vec_znx_dft(module, m_skj_univ_dft, 1, glwe_sk_dft_retrieve_vec_pos(sk_dft, j), 1, m_univ_dft, 1);
 
 			// Computes -m * sk_j
 			for (uint64_t p = 0; p < NBASE; p++)

--- a/tests/unit/core/ggsw/test_ggsw_external_product.c
+++ b/tests/unit/core/ggsw/test_ggsw_external_product.c
@@ -72,7 +72,8 @@ Test(ggsw_external_product, without_error)
 	double* um_univ_RnX               = calloc(NBASE, sizeof(double));
 
 	// Define sk_ggsw = (1, 0, ... , 0)
-	sk_ggsw->values[0][0] = 1;
+	// TODO: WHY?
+	sk_ggsw->values[0] = 1;
 
 	// Computes the bivGGSW secret key out of the DFT domain
 	transform_glwe_secret_key_not_dft_to_dft(module, sk_glwe_dft, sk_ggsw);
@@ -181,8 +182,9 @@ Test(ggsw_external_product_dft, without_error)
 	PolyBiv* um                       = malloc(poly_biv_bytes(params_glwe));
 	PolyUnivRnX* um_univ_RnX          = calloc(NBASE, sizeof(double));
 
-	// Define sk_ggsw = (1, 0, ... , 0)
-	sk_ggsw->values[0][0] = 2;
+	// Define sk_ggsw = (2, 0, ... , 0)
+	// TODO: why?
+	sk_ggsw->values[0] = 2;
 
 	// Computes the bivGGSW secret key out of the DFT domain
 	transform_glwe_secret_key_not_dft_to_dft(module, sk_glwe_dft, sk_ggsw);


### PR DESCRIPTION
Keys were strored as vectors of pointers to the polynomials that composed them. Now they store all the polynomials contiguously in a flattened way.

This could allow us to use spqlios functions on the secret keys in the future, instead of having to iterate over each sk vector position. See https://github.com/Prividema/prividema-fhe/issues/17