### PR TITLE
Move spqlios to a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spqlios-arithmetic"]
+	path = spqlios-arithmetic
+	url = https://github.com/tfhe/spqlios-arithmetic

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -7,7 +7,9 @@
 In this case make sure that pkg-config is also installed for portability between different OS.
 - For Windows users, also make sure that [Cryptography API: Next Generation](https://learn.microsoft.com/en-us/windows/win32/seccng/cng-portal) is installed, as it is required for the random number generator.
 
-- [spqlios-arithmetic](https://github.com/tfhe/spqlios-arithmetic) will be installed automatically by CMake if github.com is reachable.
+- [spqlios-arithmetic](https://github.com/tfhe/spqlios-arithmetic) is bundled as a submodule. One should:
+  - Either have cloned this repository recursively with `git clone --recurse-submodules`
+  - or run `git submodule update --init --recursive` at least once after cloning it
 
 ## To compile and run
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,14 +95,9 @@ endif()
 # Import spqlios library
 #
 # ----------------------------------------
-FetchContent_Declare(
-    spqlios
-    GIT_REPOSITORY https://github.com/tfhe/spqlios-arithmetic.git
-    GIT_TAG main
-)
 # Disable spqlios internal tests
 set(ENABLE_TESTING OFF CACHE BOOL "Disable Tests" FORCE)
-FetchContent_MakeAvailable(spqlios)
+add_subdirectory(spqlios-arithmetic)
 
 # ----------------------------------------
 # Add main source directory

--- a/docs/pages/004_building_and_testing.md
+++ b/docs/pages/004_building_and_testing.md
@@ -5,7 +5,9 @@
 
 - CMake version 3.14+
 - [Criterion](https://github.com/Snaipe/Criterion) optionally to run the unit tests. In this case make sure that pkg-config is also installed for portability between different OS.
-- [spqlios-arithmetic](https://github.com/tfhe/spqlios-arithmetic) will be installed automatically by CMake if github.com is reachable.
+- [spqlios-arithmetic](https://github.com/tfhe/spqlios-arithmetic) is bundled as a submodule. One should:
+  - Either have cloned this repository recursively with `git clone --recurse-submodules`
+  - or run `git submodule update --init --recursive` at least once
 
 ## To compile and run
 

--- a/src/backend/CMakeLists.txt
+++ b/src/backend/CMakeLists.txt
@@ -18,5 +18,5 @@ target_include_directories(PVDA_BACKEND
     PUBLIC
         ${PROJECT_SOURCE_DIR}/include/backend   # Public headers for consumers
     PRIVATE
-        ${PROJECT_SOURCE_DIR}/build/_deps/spqlios-src/spqlios/arithmetic/  # Internal headers only
+        ${PROJECT_SOURCE_DIR}/spqlios-arithmetic/spqlios/arithmetic/  # Internal headers only
 )

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -43,7 +43,6 @@ function(BuildUnitTests testfiles libname)
     target_include_directories(${test_name} PRIVATE
             ${PROJECT_SOURCE_DIR}/include
             utils/include
-            ${PROJECT_SOURCE_DIR}/build/_deps/spqlios-src/spqlios/arithmetic/
         )
 
     # Link libraries


### PR DESCRIPTION
At the moment, Prividema-fhe has a strong dependency on spqlios-arithmetic.
Nearly all performance-critical operations (apart from RNG) are delegated to it.

The old CMake FetchContent strategy is convenient for the end user, but it meant that any changes to spqlios would need to wait until they are upstreamed in the main repository to be available to prividema-fhe.

I am currently benchmarking my OnionPIR implementation, and I would like to experiment with alternative implementations/variants of the VMP operation (vector-matrix product) , since I have identified one area which might be a potential bottleneck and I have ideas for an unrelated potential optimisation. 

With FetchContent, there would be no good way to do version control on any changes I did to spqlios.
If spqlios is a submodule I can track experimental changes to it (which I can keep in a fork, for example). Without it, CMake can choose to delete any changes I make to it at any point in time.

