### PR TITLE
Fixed CMux tree normalization mode

### DIFF
--- a/examples/example_PIR.c
+++ b/examples/example_PIR.c
@@ -11,6 +11,7 @@
 #include "ggsw_ciphertext.h"
 #include "ggsw_key.h"
 #include "ggsw_params.h"
+#include "glwe_arithmetic.h"
 #include "glwe_ciphertext.h"
 #include "glwe_key.h"
 #include "glwe_params.h"
@@ -264,6 +265,8 @@ int onionpir_server(const MODULE* module, const GGSWParams* ggsw_ksk_params, con
 		CHECK_CALL_LABEL(st, "Trace by column half-product failed in onionpir server", cleanup2);
 		st = glwe_dft_to_coef(module, glwe_tree_first_level[c], tmp_glwe_dft);
 		CHECK_CALL_LABEL(st, "DFT to coefficient form failed after column half-product in onionpir server", cleanup2);
+		st = normalize_glwe(module, glwe_tree_first_level[c], glwe_tree_first_level[c]);
+		CHECK_CALL_LABEL(st, "normalization failed after column half-product in onionpir server", cleanup2);
 	}
 
 	// Delete the row selection gadget to lower peak memory consumption

--- a/src/schemes/tfhe.c
+++ b/src/schemes/tfhe.c
@@ -85,9 +85,13 @@ int tfhe_cmux_tree(const MODULE* module, GLWECiphertext* res, const GLWECipherte
 		for (c = 0; c < used_cols; c += 2)
 		{
 			if (c + 1 < used_cols)
+			{
 				CHECK_CALL(
-				    tfhe_cmux(module, glwe_tree[l + 1][c / 2], glwe_tree[l][c], glwe_tree[l][c + 1], selectors[l], 1),
+				    tfhe_cmux(module, glwe_tree[l + 1][c / 2], glwe_tree[l][c], glwe_tree[l][c + 1], selectors[l], 0),
 				    "CMux failed in a CMux tree");
+				CHECK_CALL(normalize_glwe(module, glwe_tree[l + 1][c / 2], glwe_tree[l + 1][c / 2]),
+				           "normalization failed in CMux tree");
+			}
 			else
 			{
 				glwe_copy(glwe_tree[l + 1][c / 2], glwe_tree[l][c]);


### PR DESCRIPTION
Fixed a potential bug for certain sets of parameters for CMux trees.

Normalization was being performed inside the CMux for subtraction. While this is not an issue for a single CMux provided that the inputs are sufficiently close to normalized form, it could quickly result in additions of non-normalized results of external products. Those external product results can, for standard sets of parameters, quickly come close to the maximum 64bits available per limb before lack of normalization results in an overflow that irreparably destroys the ciphertext. 

Changed the provided CMux tree implementation to use normalization after CMux instead of before. Previous behaviour is not provided due to ease of misuse and very low performance savings.

Curiously, the OnionPIR proof-of-concept was working quite well with the older version. An analysis of its characteristics would be interesting