### PR TITLE
Fix rounding bug in BFV debug/example display

### DIFF
--- a/src/core/glwe/glwe_ciphertext.c
+++ b/src/core/glwe/glwe_ciphertext.c
@@ -58,7 +58,10 @@ int print_coefs_glwe(const MODULE* module, const GLWECiphertext* glwe, const GLW
 	for (int i = 0; i < n; ++i)
 	{
 		if (shft)
-			printf("%lx (%ld)  ", result_tnx[i], ((result_tnx[i] >> (shft - 1)) + 1) >> 1);
+		{
+			uint64_t rval = ((uint64_t)result_tnx[i] + (1ull << (shft - 1))) >> shft;
+			printf("%lx (%ld)  ", result_tnx[i], rval);
+		}
 		else
 			printf("%lx (%ld) ", result_tnx[i], result_tnx[i]);
 	}


### PR DESCRIPTION
No actual error on raw computation, but the displayed value would be wrong in certain cases