### PR TITLE
Change normalization position in OnionPIR example and fix display bug

### DIFF
--- a/examples/example_PIR.c
+++ b/examples/example_PIR.c
@@ -11,6 +11,7 @@
 #include "ggsw_ciphertext.h"
 #include "ggsw_key.h"
 #include "ggsw_params.h"
+#include "glwe_arithmetic.h"
 #include "glwe_ciphertext.h"
 #include "glwe_key.h"
 #include "glwe_params.h"
@@ -264,6 +265,8 @@ int onionpir_server(const MODULE* module, const GGSWParams* ggsw_ksk_params, con
 		CHECK_CALL_LABEL(st, "Trace by column half-product failed in onionpir server", cleanup2);
 		st = glwe_dft_to_coef(module, glwe_tree_first_level[c], tmp_glwe_dft);
 		CHECK_CALL_LABEL(st, "DFT to coefficient form failed after column half-product in onionpir server", cleanup2);
+		st = normalize_glwe(module, glwe_tree_first_level[c], glwe_tree_first_level[c]);
+		CHECK_CALL_LABEL(st, "normalization failed after column half-product in onionpir server", cleanup2);
 	}
 
 	// Delete the row selection gadget to lower peak memory consumption

--- a/src/core/glwe/glwe_ciphertext.c
+++ b/src/core/glwe/glwe_ciphertext.c
@@ -58,7 +58,10 @@ int print_coefs_glwe(const MODULE* module, const GLWECiphertext* glwe, const GLW
 	for (int i = 0; i < n; ++i)
 	{
 		if (shft)
-			printf("%lx (%ld)  ", result_tnx[i], ((result_tnx[i] >> (shft - 1)) + 1) >> 1);
+		{
+			uint64_t rval = ((uint64_t)result_tnx[i] + (1ull << (shft - 1))) >> shft;
+			printf("%lx (%ld)  ", result_tnx[i], rval);
+		}
 		else
 			printf("%lx (%ld) ", result_tnx[i], result_tnx[i]);
 	}

--- a/src/schemes/tfhe.c
+++ b/src/schemes/tfhe.c
@@ -85,9 +85,13 @@ int tfhe_cmux_tree(const MODULE* module, GLWECiphertext* res, const GLWECipherte
 		for (c = 0; c < used_cols; c += 2)
 		{
 			if (c + 1 < used_cols)
+			{
 				CHECK_CALL(
-				    tfhe_cmux(module, glwe_tree[l + 1][c / 2], glwe_tree[l][c], glwe_tree[l][c + 1], selectors[l], 1),
+				    tfhe_cmux(module, glwe_tree[l + 1][c / 2], glwe_tree[l][c], glwe_tree[l][c + 1], selectors[l], 0),
 				    "CMux failed in a CMux tree");
+				CHECK_CALL(normalize_glwe(module, glwe_tree[l + 1][c / 2], glwe_tree[l + 1][c / 2]),
+				           "normalization failed in CMux tree");
+			}
 			else
 			{
 				glwe_copy(glwe_tree[l + 1][c / 2], glwe_tree[l][c]);


### PR DESCRIPTION
Changed where normalization happens in the OnionPIR CMux tree from inputs to outputs, which has allowed me to raise the amount of data in it for a ~20% performance improvement.

Also fixed a bug in the print function used in it which would fail for value 0